### PR TITLE
Revise Definition for the Anonymous Posting Viewing Permissions

### DIFF
--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -36,6 +36,18 @@ const passportAuthenticateAsync = function (req, res) {
 	});
 };
 
+// permisssions for admin to see username on anonymous posts
+const showUsername = async (userId, currentUser) => {
+	const isAdmin = await user.isAdministrator(currentUser.uid);
+
+	if (isAnonymous && !isAdmin) {
+		return 'Anonymous User';
+	}
+
+	return user.getDisplayName(userId);
+};
+
+
 
 module.exports = function (middleware) {
 	async function authenticate(req, res) {


### PR DESCRIPTION
Define the logic for anonymous posts viewing permissions in src/middleware/user.js. Revised the showUsername constant in the previous version, allowing admin users to see username display on anonymous posts, while regular users only see "Anonymous User."
attempt to solve: #18 